### PR TITLE
Fixed status response to always be 200

### DIFF
--- a/src/handlers/status.handler.ts
+++ b/src/handlers/status.handler.ts
@@ -3,12 +3,12 @@ import { isPortReachable } from '@frankmerema/is-port-reachable';
 export class StatusHandler {
 
   checkIfOpenWeatherMapIsOnline(): Promise<{ openWeatherMap: string }> {
-    return isPortReachable(80, { host: 'openweathermap.org' })
+    return isPortReachable(80, { host: 'api.openweathermap.org' })
       .then(() => ({ openWeatherMap: 'ONLINE' }))
       .catch(err => {
         /* tslint:disable-next-line */
         console.error(err);
-        return Promise.reject({ openWeatherMap: 'OFFLINE' });
+        return { openWeatherMap: 'OFFLINE' };
       });
   }
 }

--- a/src/routes/status.routes.ts
+++ b/src/routes/status.routes.ts
@@ -26,8 +26,6 @@ export class StatusRoutes {
     this.statusHandler.checkIfOpenWeatherMapIsOnline()
       .then(status => {
         res.json(status);
-      }).catch(status => {
-      res.status(404).json(status);
-    });
+      });
   }
 }

--- a/tests/handlers/status.handler.spec.ts
+++ b/tests/handlers/status.handler.spec.ts
@@ -18,13 +18,15 @@ describe('StatusHandler', () => {
     promise = Promise.resolve(true);
 
     await expect(statusHandler.checkIfOpenWeatherMapIsOnline()).resolves.toEqual({ openWeatherMap: 'ONLINE' });
-    expect(isPortReachable).toHaveBeenCalledWith(80, { host: 'openweathermap.org' });
+    expect(isPortReachable).toHaveBeenCalledWith(80, { host: 'api.openweathermap.org' });
   });
 
   test('check that the services are offline', async () => {
+    spyOn(global.console, 'error');
     promise = Promise.reject('Just because...');
 
-    await expect(statusHandler.checkIfOpenWeatherMapIsOnline()).rejects.toEqual({ openWeatherMap: 'OFFLINE' });
-    expect(isPortReachable).toHaveBeenCalledWith(80, { host: 'openweathermap.org' });
+    await expect(statusHandler.checkIfOpenWeatherMapIsOnline()).resolves.toEqual({ openWeatherMap: 'OFFLINE' });
+    expect(isPortReachable).toHaveBeenCalledWith(80, { host: 'api.openweathermap.org' });
+    expect(console.error).toHaveBeenCalledWith('Just because...');
   });
 });

--- a/tests/routes/status.routes.spec.ts
+++ b/tests/routes/status.routes.spec.ts
@@ -55,12 +55,12 @@ describe('StatusRoutes', () => {
 
     test('is offline via /', async () => {
       const customRes = { openWeatherMap: 'OFFLINE' };
-      checkWeatherOnlineFnMock.mockRejectedValueOnce(customRes);
+      checkWeatherOnlineFnMock.mockResolvedValue(customRes);
 
       const response = await request(app).get('/');
 
       expect(checkWeatherOnlineFnMock).toHaveBeenCalled();
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(200);
       expect(response.body).toEqual(customRes);
     });
   });


### PR DESCRIPTION
Fixed status response to always be 200 instead of throw a 404 if service is offline